### PR TITLE
feat: integrate orange sms provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "backend-core",
  "backend-flow-sdk",
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "backend-auth"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "async-trait",
  "axum",
@@ -966,7 +966,7 @@ dependencies = [
 
 [[package]]
 name = "backend-core"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1000,7 +1000,7 @@ dependencies = [
 
 [[package]]
 name = "backend-e2e"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "anyhow",
  "argon2",
@@ -1022,11 +1022,11 @@ dependencies = [
 
 [[package]]
 name = "backend-env"
-version = "0.2.6"
+version = "0.2.7"
 
 [[package]]
 name = "backend-flow-sdk"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "async-trait",
  "backend-env",
@@ -1049,7 +1049,7 @@ dependencies = [
 
 [[package]]
 name = "backend-id"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "backend-core",
  "cuid",
@@ -1057,7 +1057,7 @@ dependencies = [
 
 [[package]]
 name = "backend-migrate"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "async-trait",
  "backend-core",
@@ -1075,7 +1075,7 @@ dependencies = [
 
 [[package]]
 name = "backend-model"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "chrono",
  "diesel",
@@ -1089,7 +1089,7 @@ dependencies = [
 
 [[package]]
 name = "backend-repository"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "anyhow",
  "backend-core",
@@ -1113,7 +1113,7 @@ dependencies = [
 
 [[package]]
 name = "backend-server"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "apalis",
  "apalis-redis",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5829,6 +5829,7 @@ dependencies = [
  "aws-types",
  "axum",
  "backend-core",
+ "base64 0.22.1",
  "clap",
  "mimalloc",
  "reqwest 0.13.2",
@@ -5837,6 +5838,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "urlencoding",
  "wiremock",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ dotenvy = "0.15"
 chrono = { version = "0.4", features = ["serde"] }
 cuid = { version = "1" }
 regex = "1"
+urlencoding = "2"
 getrandom = "0.4"
 reqwest = { version = "0.13", default-features = false, features = ["json", "http2", "gzip", "brotli", "deflate", "rustls", "form"] }
 rustls = { version = "0.23", default-features = false, features = ["ring"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ sha2 = "0.10"
 hmac = "0.12"
 argon2 = "0.5"
 hex = "0.4"
-base64 = "0.22"
+base64 = "0.22.1"
 ring = "0.17"
 rand = "0.10"
 jsonwebtoken = { version = "10.3" }
@@ -69,7 +69,7 @@ dotenvy = "0.15"
 chrono = { version = "0.4", features = ["serde"] }
 cuid = { version = "1" }
 regex = "1"
-urlencoding = "2"
+urlencoding = "2.1.3"
 getrandom = "0.4"
 reqwest = { version = "0.13", default-features = false, features = ["json", "http2", "gzip", "brotli", "deflate", "rustls", "form"] }
 rustls = { version = "0.23", default-features = false, features = ["ring"] }
@@ -123,7 +123,7 @@ incremental = false
 strip = true
 
 [workspace.package]
-version = "0.2.6"
+version = "0.2.7"
 edition = "2024"
 license = "MIT"
 publish = false

--- a/app/bins/sms-gateway/Cargo.toml
+++ b/app/bins/sms-gateway/Cargo.toml
@@ -9,6 +9,7 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 clap = { workspace = true }
 anyhow = { workspace = true }
+base64 = { workspace = true }
 backend-core = { workspace = true, features = ["cli"] }
 mimalloc = { workspace = true }
 aws-config = { workspace = true }
@@ -16,6 +17,7 @@ aws-sdk-sns = { workspace = true }
 aws-types = { workspace = true }
 reqwest = { workspace = true }
 axum = { workspace = true }
+urlencoding = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 async-trait = { workspace = true }

--- a/app/bins/sms-gateway/src/main.rs
+++ b/app/bins/sms-gateway/src/main.rs
@@ -5,7 +5,7 @@ use clap::Parser;
 use mimalloc::MiMalloc;
 use sms_provider::{
     is_permanent_error, process_notification_job, ApiSmsProvider, AvlytextSmsProvider,
-    ConsoleSmsProvider, SnsSmsProvider,
+    ConsoleSmsProvider, OrangeSmsProvider, SnsSmsProvider,
 };
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -134,6 +134,17 @@ async fn create_sms_provider(
                 avlytext_config.base_url.clone(),
                 avlytext_config.api_key.clone(),
                 avlytext_config.sender_id.clone(),
+            )))
+        }
+        SmsProviderType::Orange => {
+            let orange_config = config.orange.as_ref().ok_or_else(|| {
+                anyhow::anyhow!("Orange configuration is required when provider is 'orange'")
+            })?;
+            info!("Using Orange SMS provider: {}", orange_config.sms_base_url);
+            let client = reqwest::Client::new();
+            Ok(Arc::new(OrangeSmsProvider::new(
+                client,
+                orange_config.clone(),
             )))
         }
     }

--- a/app/bins/sms-gateway/src/sms_provider.rs
+++ b/app/bins/sms-gateway/src/sms_provider.rs
@@ -1,10 +1,14 @@
 use async_trait::async_trait;
+use backend_core::config::OrangeConfig;
 use backend_core::{Error, NotificationJob};
+use base64::Engine;
+use serde::Deserialize;
 use serde_json::json;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
+use tokio::sync::{Mutex, RwLock};
 use tokio::time::sleep;
-use tracing::info;
+use tracing::{debug, info};
 
 #[cfg(test)]
 use wiremock::{
@@ -202,6 +206,220 @@ impl SmsProvider for ApiSmsProvider {
                 "SMS_SEND_PERMANENT",
                 format!("SMS API client error ({}): {}", status, error_text),
             ))
+        }
+    }
+}
+
+/// Orange SMS provider
+pub struct OrangeSmsProvider {
+    client: reqwest::Client,
+    config: OrangeConfig,
+    token_cache: RwLock<Option<OrangeToken>>,
+    rate_limiter: Mutex<Instant>,
+}
+
+struct OrangeToken {
+    access_token: String,
+    expires_at: Instant,
+}
+
+#[derive(Deserialize)]
+struct OrangeTokenResponse {
+    access_token: String,
+    expires_in: u64,
+}
+
+impl OrangeSmsProvider {
+    pub fn new(client: reqwest::Client, config: OrangeConfig) -> Self {
+        Self {
+            client,
+            config,
+            token_cache: RwLock::new(None),
+            rate_limiter: Mutex::new(Instant::now()),
+        }
+    }
+
+    async fn get_valid_token(&self) -> Result<String, Error> {
+        // 1. Check cache
+        {
+            let cache = self.token_cache.read().await;
+            if let Some(token) = cache.as_ref() {
+                // Refresh 5 minutes before expiry
+                if token.expires_at > Instant::now() + Duration::from_secs(300) {
+                    return Ok(token.access_token.clone());
+                }
+            }
+        }
+
+        // 2. Fetch new token
+        let mut cache = self.token_cache.write().await;
+        // Re-check after acquiring write lock
+        if let Some(token) = cache.as_ref() {
+            if token.expires_at > Instant::now() + Duration::from_secs(300) {
+                return Ok(token.access_token.clone());
+            }
+        }
+
+        debug!("Fetching new Orange OAuth token");
+        let auth_header = format!(
+            "Basic {}",
+            base64::engine::general_purpose::STANDARD
+                .encode(format!("{}:{}", self.config.client_id, self.config.client_secret))
+        );
+
+        let response = self
+            .client
+            .post(&self.config.token_url)
+            .header("Authorization", auth_header)
+            .header("Content-Type", "application/x-www-form-urlencoded")
+            .header("Accept", "application/json")
+            .body("grant_type=client_credentials")
+            .send()
+            .await
+            .map_err(|e| {
+                Error::internal(
+                    "SMS_AUTH_FAILED",
+                    format!("Failed to fetch Orange token: {}", e),
+                )
+            })?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            return Err(Error::internal(
+                "SMS_AUTH_FAILED",
+                format!("Orange token API returned {}: {}", status, body),
+            ));
+        }
+
+        let token_res: OrangeTokenResponse = response.json().await.map_err(|e| {
+            Error::internal(
+                "SMS_AUTH_FAILED",
+                format!("Failed to parse Orange token response: {}", e),
+            )
+        })?;
+
+        let access_token = token_res.access_token;
+        let expires_at = Instant::now() + Duration::from_secs(token_res.expires_in);
+
+        *cache = Some(OrangeToken {
+            access_token: access_token.clone(),
+            expires_at,
+        });
+
+        Ok(access_token)
+    }
+
+    fn normalize_msisdn(&self, msisdn: &str) -> String {
+        let digits: String = msisdn.chars().filter(|c| c.is_ascii_digit()).collect();
+        if digits.starts_with("237") && digits.len() == 12 {
+            format!("tel:+{}", digits)
+        } else if digits.len() == 9 {
+            format!("tel:+237{}", digits)
+        } else {
+            format!("tel:+{}", digits)
+        }
+    }
+
+    async fn send_once(&self, msisdn: &str, otp: &str) -> Result<(), Error> {
+        let token = self.get_valid_token().await?;
+        let normalized_to = self.normalize_msisdn(msisdn);
+        let normalized_from = self.normalize_msisdn(&self.config.default_sender);
+
+        // Throttle to 5 SMS per second (200ms per request)
+        {
+            let mut last_send = self.rate_limiter.lock().await;
+            let now = Instant::now();
+            let elapsed = now.duration_since(*last_send);
+            let wait_time = Duration::from_millis(200);
+            if elapsed < wait_time {
+                sleep(wait_time - elapsed).await;
+            }
+            *last_send = Instant::now();
+        }
+
+        let url = format!(
+            "{}/outbound/{}/requests",
+            self.config.sms_base_url.trim_end_matches('/'),
+            urlencoding::encode(&normalized_from)
+        );
+
+        let payload = json!({
+            "outboundSMSMessageRequest": {
+                "address": normalized_to,
+                "senderAddress": normalized_from,
+                "outboundSMSTextMessage": {
+                    "message": format!("Your verification code is: {}", otp)
+                }
+            }
+        });
+
+        let response = self
+            .client
+            .post(&url)
+            .header("Authorization", format!("Bearer {}", token))
+            .header("Content-Type", "application/json")
+            .header("Accept", "application/json")
+            .json(&payload)
+            .send()
+            .await
+            .map_err(|e| {
+                Error::internal(
+                    "SMS_SEND_TRANSIENT",
+                    format!("Failed to contact Orange API: {}", e),
+                )
+            })?;
+
+        let status = response.status();
+        if status.is_success() {
+            Ok(())
+        } else if status == reqwest::StatusCode::UNAUTHORIZED {
+            // Token might be expired, clear cache
+            let mut cache = self.token_cache.write().await;
+            *cache = None;
+            Err(Error::internal(
+                "SMS_SEND_TRANSIENT",
+                "Orange API returned 401 Unauthorized, token cleared",
+            ))
+        } else if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+            Err(Error::internal(
+                "SMS_SEND_TRANSIENT",
+                "Orange API rate limit exceeded (429)",
+            ))
+        } else if status.is_server_error() {
+            let body = response.text().await.unwrap_or_default();
+            Err(Error::internal(
+                "SMS_SEND_TRANSIENT",
+                format!("Orange API server error ({}): {}", status, body),
+            ))
+        } else {
+            let body = response.text().await.unwrap_or_default();
+            // Handle "Insufficient bundle" or other client errors as permanent
+            if body.contains("EXPIRED_QUOTA") || body.contains("OUT_OF_BALANCE") {
+                 Err(Error::internal(
+                    "SMS_SEND_PERMANENT",
+                    format!("Orange API reported insufficient balance: {}", body),
+                ))
+            } else {
+                Err(Error::internal(
+                    "SMS_SEND_PERMANENT",
+                    format!("Orange API client error ({}): {}", status, body),
+                ))
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl SmsProvider for OrangeSmsProvider {
+    async fn send_otp(&self, msisdn: &str, otp: &str) -> Result<(), Error> {
+        match self.send_once(msisdn, otp).await {
+            Ok(()) => Ok(()),
+            Err(e) if is_transient_error(&e) => {
+                // If it was a 401, send_once already cleared the token, so retry will fetch a new one
+                self.send_once(msisdn, otp).await
+            }
+            Err(e) => Err(e),
         }
     }
 }
@@ -448,6 +666,43 @@ mod tests {
             .await;
 
         let result = provider.send_otp("1234567890", "123456").await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn orange_sms_provider_sends_sms() {
+        let server = MockServer::start().await;
+        let client = reqwest::Client::new();
+        let config = OrangeConfig {
+            client_id: "test_id".to_string(),
+            client_secret: "test_secret".to_string(),
+            token_url: format!("{}/token", server.uri()),
+            sms_base_url: server.uri(),
+            contract_url: "".to_string(),
+            default_sender: "+237000000000".to_string(),
+        };
+        let provider = OrangeSmsProvider::new(client, config);
+
+        // 1. Mock Token API
+        Mock::given(method("POST"))
+            .and(path("/token"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "access_token": "test_token",
+                "expires_in": 3600
+            })))
+            .mount(&server)
+            .await;
+
+        // 2. Mock SMS API
+        let sender_path = urlencoding::encode("tel:+237000000000");
+        Mock::given(method("POST"))
+            .and(path(format!("/outbound/{}/requests", sender_path)))
+            .and(wiremock::matchers::header("Authorization", "Bearer test_token"))
+            .respond_with(ResponseTemplate::new(201))
+            .mount(&server)
+            .await;
+
+        let result = provider.send_otp("+237654066316", "123456").await;
         assert!(result.is_ok());
     }
 }

--- a/app/crates/backend-core/src/config.rs
+++ b/app/crates/backend-core/src/config.rs
@@ -164,6 +164,7 @@ pub enum SmsProviderType {
     Sns,
     Api,
     Avlytext,
+    Orange,
 }
 
 /// SMS configuration for OTP delivery.
@@ -174,6 +175,8 @@ pub struct SmsConfig {
     pub api: Option<SmsApi>,
     #[serde(default)]
     pub avlytext: Option<AvlytextConfig>,
+    #[serde(default)]
+    pub orange: Option<OrangeConfig>,
 }
 
 /// Third-party SMS API configuration.
@@ -189,6 +192,17 @@ pub struct AvlytextConfig {
     pub base_url: String,
     pub api_key: String,
     pub sender_id: String,
+}
+
+/// Orange SMS provider configuration.
+#[derive(Debug, Clone, Deserialize)]
+pub struct OrangeConfig {
+    pub client_id: String,
+    pub client_secret: String,
+    pub token_url: String,
+    pub sms_base_url: String,
+    pub contract_url: String,
+    pub default_sender: String,
 }
 
 /// Flow configuration for YAML-based flow and session definitions.

--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -125,7 +125,7 @@ sns:
 # Controls how SMS messages are sent for OTP and notifications.
 sms:
   # SMS provider: "console" (logs only), "sns" (AWS SNS), "avlytext" (AvlyText API).
-  provider: console
+  provider: orange
   # AvlyText API configuration (used when provider=avlytext).
   avlytext:
     # Base URL for AvlyText API.
@@ -134,6 +134,20 @@ sms:
     api_key: ""
     # Sender ID shown in SMS messages (requires approval).
     sender_id: ""
+  # Orange API configuration (used when provider=orange).
+  orange:
+    # Orange OAuth client ID.
+    client_id: ""
+    # Orange OAuth client secret.
+    client_secret: ""
+    # Orange OAuth token URL.
+    token_url: "https://api.orange.com/oauth/v3/token"
+    # Orange SMS messaging API base URL.
+    sms_base_url: "https://api.orange.com/smsmessaging/v1"
+    # Orange SMS admin API (for contracts).
+    contract_url: "https://api.orange.com/sms/admin/v1"
+    # Orange default sender phone number (+237...).
+    default_sender: "SMS 813941"
 
 # OAuth2 / OIDC Configuration
 # JWT token validation settings for API authentication.


### PR DESCRIPTION

This PR adds support for **Orange SMS (Cameroon)** as a new provider in the SMS Gateway. It includes a robust implementation of Orange's OAuth 2.0 flow, rate limiting, and phone number normalization.

### Key Changes

#### 1. Orange SMS Provider Implementation
*   **OAuth 2.0 Auth**: Implemented the Client Credentials flow to fetch access tokens from `api.orange.com`.
*   **Token Management**: Added a token caching layer that reuses tokens for up to 55 minutes, reducing unnecessary API calls.
*   **Rate Limiting**: Added a built-in throttle of **5 SMS per second** to comply with Orange's throughput constraints.
*   **Normalization**: Added automatic formatting for Cameroon phone numbers to the required `tel:+237XXXXXXXXX` format.
*   **Resiliency**: Handled 401 Unauthorized errors by automatically clearing the cache and retrying with a fresh token.

#### 2. Configuration & Infrastructure
*   **Core Config**: Added `OrangeConfig` and `Orange` provider type to `backend-core`.
*   **Environment**: Configured the provider in `config/dev.yaml` with all required endpoints (Token, Messaging, and Contract URLs).
*   **Dependencies**: Added `urlencoding` and `base64` crates to the workspace for request signing and path encoding.

#### 3. Quality Assurance
*   **Unit Tests**: Added a new test suite `orange_sms_provider_sends_sms` using `wiremock` to simulate Orange's API behavior.
*   **Manual Verification**: Successfully verified the integration with a live Orange bundle, confirming that requests are correctly accepted and processed by the Orange messaging engine.
