### PR TITLE
fix(auth): correct metadata key for fineractClientId in first_deposit…

### DIFF
--- a/flows/first_deposit.yaml
+++ b/flows/first_deposit.yaml
@@ -143,7 +143,7 @@ steps:
     actor: SYSTEM
     config:
       mappings:
-        - target_path: /fineractId
+        - target_path: /fineractClientId
           source: flow
           source_path: /step_output/cuss_register_customer/fineractClientId
           eager: true


### PR DESCRIPTION
 This PR fixes a naming mismatch in the 
`first_deposit.yaml`
 flow by correcting the metadata key from /fineractId to /fineractClientId. This ensures the BFF can successfully resolve the user's Fineract identity and resolves the 403 Forbidden errors during payment transactions.
 Logs from the bff:
> 2026-04-08T07:24:14.521Z  WARN 1 --- [azamra-tokenization-bff] [or-http-epoll-2] c.a.b.a.service.UserContextService       : fineractClientId not found in user storage metadata for user usr_cmnn1beic01k5yz014am6zc6t. Available keys: []