### PR TITLE
feat(observability): add Prometheus metrics endpoint and correlation ID middleware

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,6 +102,8 @@ opentelemetry = { version = "0.29.0" }
 opentelemetry_sdk = { version = "0.29.0", features = ["rt-tokio"] }
 opentelemetry-otlp = { version = "0.29.0", features = ["trace", "grpc-tonic"] }
 tracing-opentelemetry = "0.30.0"
+metrics = "0.24"
+metrics-exporter-prometheus = "0.16"
 
 mockall = "0.14"
 glob = "0.3"

--- a/app/crates/backend-server/Cargo.toml
+++ b/app/crates/backend-server/Cargo.toml
@@ -98,6 +98,7 @@ aws-types = { workspace = true }
 metrics = { workspace = true }
 metrics-exporter-prometheus = { workspace = true }
 cuid = { workspace = true }
+getrandom = { workspace = true }
 
 gen_oas_server_kc = { workspace = true }
 gen_oas_client_cuss = { workspace = true }

--- a/app/crates/backend-server/Cargo.toml
+++ b/app/crates/backend-server/Cargo.toml
@@ -95,6 +95,9 @@ wiremock = { workspace = true, optional = true }
 aws-config = { workspace = true }
 aws-sdk-s3 = { workspace = true }
 aws-types = { workspace = true }
+metrics = { workspace = true }
+metrics-exporter-prometheus = { workspace = true }
+cuid = { workspace = true }
 
 gen_oas_server_kc = { workspace = true }
 gen_oas_client_cuss = { workspace = true }

--- a/app/crates/backend-server/src/correlation_id.rs
+++ b/app/crates/backend-server/src/correlation_id.rs
@@ -1,6 +1,6 @@
 //! Correlation ID middleware.
 //!
-//! Extracts `X-Correlation-ID` from incoming requests (or generates a new CUID2
+//! Extracts `X-Correlation-ID` from incoming requests (or generates a new CUID
 //! if absent), records it on the current tracing span, and returns it in the
 //! response header so callers can correlate logs across services.
 
@@ -13,7 +13,7 @@ use tracing::Span;
 /// Axum middleware that propagates or generates a correlation ID.
 ///
 /// Reads `X-Correlation-ID` from the request headers. If absent, generates
-/// a new CUID2. The value is:
+/// a new CUID. The value is:
 /// - Recorded on the active tracing span as `correlation_id`
 /// - Returned on the response as `X-Correlation-ID`
 pub async fn correlation_id_middleware(req: Request<Body>, next: Next) -> Response {
@@ -22,7 +22,15 @@ pub async fn correlation_id_middleware(req: Request<Body>, next: Next) -> Respon
         .get("X-Correlation-ID")
         .and_then(|v| v.to_str().ok())
         .map(|s| s.to_owned())
-        .unwrap_or_else(|| cuid::cuid1().unwrap_or_else(|_| "unknown".to_owned()));
+        .unwrap_or_else(|| {
+            cuid::cuid1().unwrap_or_else(|_| {
+                // Fallback: generate a random 16-byte hex string so every request
+                // gets a unique ID even when cuid generation fails.
+                let mut bytes = [0u8; 16];
+                let _ = getrandom::fill(&mut bytes);
+                bytes.iter().map(|b| format!("{b:02x}")).collect()
+            })
+        });
 
     Span::current().record("correlation_id", correlation_id.as_str());
 

--- a/app/crates/backend-server/src/correlation_id.rs
+++ b/app/crates/backend-server/src/correlation_id.rs
@@ -1,0 +1,36 @@
+//! Correlation ID middleware.
+//!
+//! Extracts `X-Correlation-ID` from incoming requests (or generates a new CUID2
+//! if absent), records it on the current tracing span, and returns it in the
+//! response header so callers can correlate logs across services.
+
+use axum::body::Body;
+use axum::http::{HeaderValue, Request};
+use axum::middleware::Next;
+use axum::response::Response;
+use tracing::Span;
+
+/// Axum middleware that propagates or generates a correlation ID.
+///
+/// Reads `X-Correlation-ID` from the request headers. If absent, generates
+/// a new CUID2. The value is:
+/// - Recorded on the active tracing span as `correlation_id`
+/// - Returned on the response as `X-Correlation-ID`
+pub async fn correlation_id_middleware(req: Request<Body>, next: Next) -> Response {
+    let correlation_id = req
+        .headers()
+        .get("X-Correlation-ID")
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_owned())
+        .unwrap_or_else(|| cuid::cuid1().unwrap_or_else(|_| "unknown".to_owned()));
+
+    Span::current().record("correlation_id", correlation_id.as_str());
+
+    let mut response = next.run(req).await;
+
+    if let Ok(value) = HeaderValue::from_str(&correlation_id) {
+        response.headers_mut().insert("X-Correlation-ID", value);
+    }
+
+    response
+}

--- a/app/crates/backend-server/src/lib.rs
+++ b/app/crates/backend-server/src/lib.rs
@@ -8,8 +8,10 @@
 pub(crate) mod api;
 pub(crate) mod auth_signature;
 pub(crate) mod bff_auth;
+pub(crate) mod correlation_id;
 pub(crate) mod flows;
 pub(crate) mod health;
+pub mod metrics;
 pub(crate) mod object_storage;
 pub(crate) mod state;
 pub(crate) mod swagger;
@@ -26,6 +28,7 @@ use backend_auth::{jwks_auth_layer, kc_signature_layer};
 use backend_core::{Config, Result};
 use backend_migrate::connect_postgres_and_migrate;
 use hyper::StatusCode;
+use metrics_exporter_prometheus::PrometheusHandle;
 use std::sync::Arc;
 use tower_http::trace::TraceLayer;
 use tracing::info;
@@ -47,6 +50,7 @@ use tracing::info;
 /// Returns an error if initialization fails or the server cannot start
 pub async fn serve(core_config: &Config, imports: flow_registry::RegistryImports) -> Result<()> {
     let listen_addr = core_config.api_listen_addr()?;
+    let prometheus_handle = metrics::install_prometheus_recorder();
     let pool = connect_postgres_and_migrate(&core_config.database.url).await?;
     let state = Arc::new(state::AppState::from_config(core_config, pool, imports).await?);
 
@@ -55,7 +59,7 @@ pub async fn serve(core_config: &Config, imports: flow_registry::RegistryImports
         state.oidc_state.clone(),
         state.signature_state.clone(),
     );
-    let app = build_router(api, &state.config, state.oidc_state.clone());
+    let app = build_router(api, &state.config, state.oidc_state.clone(), prometheus_handle);
 
     info!("Listening on {}", listen_addr);
 
@@ -191,9 +195,12 @@ fn build_router(
     api: api::BackendApi,
     config: &Config,
     oidc_state: Arc<backend_auth::OidcState>,
+    prometheus_handle: PrometheusHandle,
 ) -> Router {
     // Mount sub-routers onto a fresh root router
-    let mut router = Router::new().merge(health::health_router());
+    let mut router = Router::new()
+        .merge(health::health_router())
+        .merge(metrics::metrics_router(prometheus_handle));
 
     // Mount KC router if base path is provided
     let kc_base = config.kc.base_path.trim();
@@ -261,6 +268,11 @@ fn build_router(
 
     router = router.layer(jwks_auth_layer(oidc_state, jwks_base_paths));
 
+    // Apply correlation ID middleware (outermost so it runs first and last)
+    router = router.layer(axum::middleware::from_fn(
+        correlation_id::correlation_id_middleware,
+    ));
+
     if config.logging.log_requests_enabled {
         router.layer(
             TraceLayer::new_for_http()
@@ -270,11 +282,17 @@ fn build_router(
                         .get::<axum::extract::ConnectInfo<std::net::SocketAddr>>()
                         .map(|ci| ci.0.to_string())
                         .unwrap_or_else(|| "unknown".to_string());
+                    let correlation_id = req
+                        .headers()
+                        .get("X-Correlation-ID")
+                        .and_then(|v| v.to_str().ok())
+                        .unwrap_or("-");
                     tracing::info_span!(
                         "http-request",
                         method = %req.method(),
                         path = %request_path(req),
                         remote_addr = %remote_addr,
+                        correlation_id = %correlation_id,
                     )
                 })
                 .on_request(|req: &HttpRequest<_>, _span: &tracing::Span| {

--- a/app/crates/backend-server/src/metrics.rs
+++ b/app/crates/backend-server/src/metrics.rs
@@ -1,0 +1,43 @@
+//! Prometheus metrics endpoint.
+//!
+//! Installs a global Prometheus recorder and exposes a `GET /metrics` handler
+//! that returns metrics in the standard Prometheus text format.
+
+use axum::Router;
+use axum::extract::State;
+use axum::routing::get;
+use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle};
+use std::sync::OnceLock;
+
+static PROMETHEUS_HANDLE: OnceLock<PrometheusHandle> = OnceLock::new();
+
+/// Installs the global Prometheus metrics recorder.
+///
+/// Must be called once at application startup, before the HTTP server starts.
+/// Panics if called more than once (safe due to `OnceLock`).
+pub fn install_prometheus_recorder() -> PrometheusHandle {
+    let handle = PrometheusBuilder::new()
+        .install_recorder()
+        .expect("failed to install Prometheus recorder");
+    PROMETHEUS_HANDLE
+        .set(handle.clone())
+        .expect("Prometheus recorder already installed");
+    handle
+}
+
+/// Builds a router with the `/metrics` endpoint.
+///
+/// # Arguments
+/// * `handle` - The Prometheus handle returned by [`install_prometheus_recorder`]
+///
+/// # Returns
+/// Axum `Router` with `GET /metrics` route
+pub fn metrics_router(handle: PrometheusHandle) -> Router {
+    Router::new()
+        .route("/metrics", get(metrics_handler))
+        .with_state(handle)
+}
+
+async fn metrics_handler(State(handle): State<PrometheusHandle>) -> String {
+    handle.render()
+}


### PR DESCRIPTION
## Summary

- Add `metrics` + `metrics-exporter-prometheus` dependencies to workspace and backend-server
- Install a global Prometheus recorder at server startup; expose `GET /metrics` returning metrics in Prometheus text format
- Add `correlation_id` middleware: reads `X-Correlation-ID` from request headers (or generates a CUID1 if absent), records it on the active tracing span, and returns it in the response so clients can correlate logs across services
- `TraceLayer` `make_span_with` now captures `correlation_id` field — all log lines within a request span include the correlation ID
- OTel tracing and JSON structured logging were already in place via `telemetry.rs`

## Test plan

- [ ] `cargo check --package backend-server` passes
- [ ] `GET /metrics` returns Prometheus text on the running server
- [ ] All responses include `X-Correlation-ID` header; requests that include it get the same value echoed back
- [ ] Log output (JSON mode) includes `correlation_id` field on request spans

🤖 Generated with [Claude Code](https://claude.com/claude-code)