### PR TITLE
feat(kyc): gate phone OTP flow on cuss-side phone uniqueness

### DIFF
--- a/.docker/e2e/stubs/cuss/src/server.ts
+++ b/.docker/e2e/stubs/cuss/src/server.ts
@@ -1,6 +1,6 @@
 import Fastify, { FastifyInstance, type FastifyReply } from 'fastify';
 
-type Endpoint = 'register' | 'approve' | 'webhook-auth-test';
+type Endpoint = 'register' | 'approve' | 'webhook-auth-test' | 'check-phone';
 
 interface FaultConfig {
   status: number;
@@ -25,6 +25,7 @@ const state = {
     register: null as FaultConfig | null,
     approve: null as FaultConfig | null,
     'webhook-auth-test': null as FaultConfig | null,
+    'check-phone': null as FaultConfig | null,
   } as Record<Endpoint, FaultConfig | null>,
   counter: 1,
 };
@@ -95,6 +96,22 @@ app.post('/api/registration/approve-and-deposit', async (req, reply) => {
   });
 });
 
+app.post('/api/registration/check-phone', async (req, reply) => {
+  if (tryFault('check-phone', reply)) {
+    return;
+  }
+
+  const payload = req.body as Record<string, unknown>;
+  const authHeader = req.headers.authorization;
+  record('check-phone', req.url, req.method, { ...payload, authHeader });
+
+  // Default behavior in e2e: phone is never already registered, so the gate
+  // continues to set_user_phone_number. Tests that need the duplicate-phone
+  // path inject a fault via /__admin/faults that returns
+  // { exists: true, externalId: "..." } on the next call.
+  reply.code(200).send({ exists: false });
+});
+
 app.post('/api/webhook-auth-test', async (req, reply) => {
   const authHeader = req.headers.authorization;
   record('webhook-auth-test', req.url, req.method, { authHeader });
@@ -115,6 +132,7 @@ app.post('/__admin/reset', async (_, reply) => {
     register: null,
     approve: null,
     'webhook-auth-test': null,
+    'check-phone': null,
   };
   state.counter = 1;
   reply.send({ reset: true });
@@ -128,8 +146,8 @@ app.post('/__admin/faults', async (req, reply) => {
     count?: number;
   };
 
-  if (!endpoint || !['register', 'approve', 'webhook-auth-test'].includes(endpoint)) {
-    reply.code(400).send({ error: 'endpoint must be register, approve, or webhook-auth-test' });
+  if (!endpoint || !['register', 'approve', 'webhook-auth-test', 'check-phone'].includes(endpoint)) {
+    reply.code(400).send({ error: 'endpoint must be register, approve, webhook-auth-test, or check-phone' });
     return;
   }
 

--- a/deploy/charts/user-storage/flows/phone_otp.yaml
+++ b/deploy/charts/user-storage/flows/phone_otp.yaml
@@ -95,7 +95,69 @@ steps:
       message: "Phone OTP verified"
       flow_pointers:
       - /step_output/verify_otp
-    next: set_user_phone_number
+    next: check_phone_unique
+
+  # Cuss-side phone-uniqueness gate. We hit cuss as soon as the user has
+  # proved phone ownership; if the phone is already linked to another
+  # Fineract client we end the flow with FAILED rather than letting the
+  # user continue through legal acceptance + admin review only to wedge
+  # at cuss_register_customer in the first_deposit flow.
+  #
+  # POST + JSON body (not GET + ?phone=...) so the literal `+` in E.164
+  # phones survives transit — Spring's @RequestParam decodes `+` as
+  # space, which would break every lookup.
+  check_phone_unique:
+    action: WEBHOOK_HTTP
+    actor: SYSTEM
+    config:
+      url: "${CUSS_URL}/api/registration/check-phone"
+      method: POST
+      timeout_ms: 5000
+      retryable: false
+      auth:
+        type: oauth2
+        token_url: "${KC_TOKEN_URL}"
+        client_id: "${CUSS_CLIENT_ID}"
+        client_secret: "${CUSS_CLIENT_SECRET}"
+      payload_mappings:
+        - source: session
+          source_path: /phone_number
+          target_path: /phone
+      success_condition:
+        status_codes: [200]
+      extraction_rules:
+        - json_pointer: /exists
+          target_path: /phone_already_registered
+          target_context: flow_context
+        - json_pointer: /externalId
+          target_path: /existing_external_id_for_phone
+          target_context: flow_context
+    next: gate_phone_uniqueness
+    fail: FAILED
+
+  gate_phone_uniqueness:
+    action: CONDITIONAL
+    actor: SYSTEM
+    config:
+      source: flow
+      pointer: /phone_already_registered
+      cases:
+        "true": phone_already_registered_terminal
+        "false": continue_to_set_phone
+      default_branch: continue_to_set_phone
+    branches:
+      phone_already_registered_terminal: phone_already_registered_terminal
+      continue_to_set_phone: set_user_phone_number
+    fail: FAILED
+
+  phone_already_registered_terminal:
+    action: DEBUG_LOG
+    actor: SYSTEM
+    config:
+      message: "Phone OTP gate: phone is already linked to another Fineract client"
+      flow_pointers:
+      - /existing_external_id_for_phone
+    next: FAILED
 
   set_user_phone_number:
     action: update-phone-number

--- a/flows/phone_otp.yaml
+++ b/flows/phone_otp.yaml
@@ -102,12 +102,16 @@ steps:
   # Fineract client we end the flow with FAILED rather than letting the
   # user continue through legal acceptance + admin review only to wedge
   # at cuss_register_customer in the first_deposit flow.
+  #
+  # POST + JSON body (not GET + ?phone=...) so the literal `+` in E.164
+  # phones survives transit — Spring's @RequestParam decodes `+` as
+  # space, which would break every lookup.
   check_phone_unique:
     action: WEBHOOK_HTTP
     actor: SYSTEM
     config:
-      url: "${CUSS_URL}/api/registration/check-phone?phone={{ session.phone_number }}"
-      method: GET
+      url: "${CUSS_URL}/api/registration/check-phone"
+      method: POST
       timeout_ms: 5000
       retryable: false
       auth:
@@ -115,6 +119,10 @@ steps:
         token_url: "${KC_TOKEN_URL}"
         client_id: "${CUSS_CLIENT_ID}"
         client_secret: "${CUSS_CLIENT_SECRET}"
+      payload_mappings:
+        - source: session
+          source_path: /phone_number
+          target_path: /phone
       success_condition:
         status_codes: [200]
       extraction_rules:

--- a/flows/phone_otp.yaml
+++ b/flows/phone_otp.yaml
@@ -95,7 +95,61 @@ steps:
       message: "Phone OTP verified"
       flow_pointers:
       - /step_output/verify_otp
-    next: set_user_phone_number
+    next: check_phone_unique
+
+  # Cuss-side phone-uniqueness gate. We hit cuss as soon as the user has
+  # proved phone ownership; if the phone is already linked to another
+  # Fineract client we end the flow with FAILED rather than letting the
+  # user continue through legal acceptance + admin review only to wedge
+  # at cuss_register_customer in the first_deposit flow.
+  check_phone_unique:
+    action: WEBHOOK_HTTP
+    actor: SYSTEM
+    config:
+      url: "${CUSS_URL}/api/registration/check-phone?phone={{ session.phone_number }}"
+      method: GET
+      timeout_ms: 5000
+      retryable: false
+      auth:
+        type: oauth2
+        token_url: "${KC_TOKEN_URL}"
+        client_id: "${CUSS_CLIENT_ID}"
+        client_secret: "${CUSS_CLIENT_SECRET}"
+      success_condition:
+        status_codes: [200]
+      extraction_rules:
+        - json_pointer: /exists
+          target_path: /phone_already_registered
+          target_context: flow_context
+        - json_pointer: /externalId
+          target_path: /existing_external_id_for_phone
+          target_context: flow_context
+    next: gate_phone_uniqueness
+    fail: FAILED
+
+  gate_phone_uniqueness:
+    action: CONDITIONAL
+    actor: SYSTEM
+    config:
+      source: flow
+      pointer: /phone_already_registered
+      cases:
+        "true": phone_already_registered_terminal
+        "false": continue_to_set_phone
+      default_branch: continue_to_set_phone
+    branches:
+      phone_already_registered_terminal: phone_already_registered_terminal
+      continue_to_set_phone: set_user_phone_number
+    fail: FAILED
+
+  phone_already_registered_terminal:
+    action: DEBUG_LOG
+    actor: SYSTEM
+    config:
+      message: "Phone OTP gate: phone is already linked to another Fineract client"
+      flow_pointers:
+      - /existing_external_id_for_phone
+    next: FAILED
 
   set_user_phone_number:
     action: update-phone-number


### PR DESCRIPTION
Closes the UX hole where a user with a phone already linked to another Fineract client could complete OTP, accept legal terms, and wait on admin review only to wedge silently at cuss_register_customer in the first_deposit flow.

fineract-apps PR #366 turned that silent wedge into a structured DUPLICATE_PHONE error at the registration layer (defense-in-depth), but the failure still happens at the very last stage. This PR moves the gate to the right place: right after VERIFY_OTP succeeds in flows/phone_otp.yaml.

## Flow change

Before:
`verify_otp (verified) -> debug_verified_otp -> set_user_phone_number -> mark_phone_verified -> COMPLETE`

After:
`verify_otp (verified) -> debug_verified_otp -> check_phone_unique -> gate_phone_uniqueness`
- if exists=true: -> phone_already_registered_terminal -> FAILED
- if exists=false: -> set_user_phone_number -> mark_phone_verified -> COMPLETE

## Dependencies (merge order)

1. fineract-apps PR #369 (https://github.com/ADORSYS-GIS/fineract-apps/pull/369) — adds the GET /check-phone endpoint
2. cuss image deployed
3. **This PR** merged + keybound-backend image deployed

If this lands before #369's image is up, every phone OTP flow ends in FAILED. Don't merge until cuss is live.

## Test plan

- [x] YAML parses cleanly (yaml.safe_load).
- [x] Step wiring verified: debug_verified_otp.next=check_phone_unique, gate branches correct.
- [ ] Reviewer: cargo check -p backend-flow-sdk + cargo test (no cargo on author's machine).
- [ ] Reviewer: e2e — register a phone, then try same phone from another device → second flow ends FAILED.
- [ ] Reviewer: confirm `+` in E.164 phones survives the URL template substitution into Spring's `@RequestParam` on the cuss side (may need URL-encoding or POST body if it decodes as space).

🤖 Generated with [Claude Code](https://claude.com/claude-code)