### PR TITLE
chore(release): bump workspace version to 0.2.8 and document CI release gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -349,3 +349,43 @@ just test-cucumber-all
 - Supports env var expansion: `${VAR}` or `${VAR:-default}`
 - Use `clap` for CLI args in binaries
 - Shared state in `AppState` with `Arc<dyn Trait>` abstractions
+
+## Versioning & CI Release Gate
+
+The `container-build-prod` job (`ci.yaml`) builds & pushes the `user-storage` and
+`sms-gateway` images (used by the dev environment via the `latest` tag) **only when
+the workspace version changes**.
+
+To determine this, the `cargo-version` job compares the `[workspace.package].version`
+in `Cargo.toml` against the most recent git tag:
+
+```bash
+latest_tag="$(git describe --tags --abbrev=0 2>/dev/null || echo none)"
+```
+
+If the version is unchanged, `cargo-version.outputs.changed` is `false` and the
+container build is **skipped** (this is intentional, to avoid burning runner minutes
+when nothing is released).
+
+**Before merging any change to `master` that should produce a deployable image, bump
+the workspace version.**
+
+```bash
+# In Cargo.toml:
+[workspace.package]
+version = "0.2.8"   # <- bump (e.g. 0.2.7 -> 0.2.8)
+```
+
+Guidelines:
+
+- Use [SemVer](https://semver.org/): bump **patch** for bug fixes, **minor** for
+  additive/backward-compatible features, **major** for breaking changes.
+- Bumping only `[workspace.package].version` is enough — all crates that use
+  `version.workspace = true` inherit it. `sms-gateway` keeps its own version and does
+  not need changing.
+- After editing `Cargo.toml`, run `cargo check` (or any cargo command) so `Cargo.lock`
+  is refreshed to the new version, and commit both files.
+- The `latest` image tag used by the dev deployment is only produced on `master`.
+
+If you change code without bumping the version, tests and MUSL builds still run, but
+the container images will **not** be rebuilt/pushed.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "backend-core",
  "backend-flow-sdk",
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "backend-auth"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "async-trait",
  "axum",
@@ -966,7 +966,7 @@ dependencies = [
 
 [[package]]
 name = "backend-core"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1000,7 +1000,7 @@ dependencies = [
 
 [[package]]
 name = "backend-e2e"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "anyhow",
  "argon2",
@@ -1022,11 +1022,11 @@ dependencies = [
 
 [[package]]
 name = "backend-env"
-version = "0.2.7"
+version = "0.2.8"
 
 [[package]]
 name = "backend-flow-sdk"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "async-trait",
  "backend-env",
@@ -1049,7 +1049,7 @@ dependencies = [
 
 [[package]]
 name = "backend-id"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "backend-core",
  "cuid",
@@ -1057,7 +1057,7 @@ dependencies = [
 
 [[package]]
 name = "backend-migrate"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "async-trait",
  "backend-core",
@@ -1075,7 +1075,7 @@ dependencies = [
 
 [[package]]
 name = "backend-model"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "chrono",
  "diesel",
@@ -1089,7 +1089,7 @@ dependencies = [
 
 [[package]]
 name = "backend-repository"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "anyhow",
  "backend-core",
@@ -1113,7 +1113,7 @@ dependencies = [
 
 [[package]]
 name = "backend-server"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "apalis",
  "apalis-redis",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,7 +125,7 @@ incremental = false
 strip = true
 
 [workspace.package]
-version = "0.2.7"
+version = "0.2.8"
 edition = "2024"
 license = "MIT"
 publish = false


### PR DESCRIPTION
## Summary

Bumps the workspace version to `0.2.8` so the CI release gate produces the `user-storage` and `sms-gateway` container images (including the `latest` tag used by the dev environment).

## Why

After the **M-Target SMS provider** merge (#43), the `sms-gateway` docker image was **not built/pushed** to GHCR, and a couple of workflows were skipped. Root cause: `container-build-prod` (`.github/workflows/ci.yaml`) only runs when `cargo-version.outputs.changed == 'true'`, which compares `[workspace.package].version` in `Cargo.toml` against the latest git tag. The M-Target PR changed code but did **not** bump the version, so the image build was skipped.

We intentionally **kept** the version-bump gate (it prevents burning runners when nothing changed) and instead trigger the pipeline by bumping the version.

## Changes

- **`Cargo.toml`**: `[workspace.package].version` `0.2.7 → 0.2.8` (all crates using `version.workspace = true` inherit it; `sms-gateway` keeps its own version).
- **`Cargo.lock`**: refreshed to `0.2.8` for workspace members (`cargo check`).
- **`AGENTS.md`**: added a "Versioning & CI Release Gate" section so contributors know to bump the workspace version for the container images to be built/pushed on `master`.

## Expected result

On merge to `master`, `cargo-version` sees the version change → `container-build-prod` builds and pushes the `user-storage` and `sms-gateway` images (including `latest`) for deployment to the dev environment.

## Notes

- The currently fetched tag `user-storage-0.1.0` is not a valid `vX.Y.Z` version tag, so `git describe` falls back to `none` and `changed` defaults to `true`; creating proper release tags will make the gate behave precisely as intended.