### PR TITLE
feat(ci): support manual dispatch to force container image build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,6 +57,11 @@ on:
         required: false
         default: 'false'
         type: boolean
+      force_build:
+        description: 'Force container image build/push (ignores change detection and version bump)'
+        required: false
+        default: 'false'
+        type: boolean
 
 # Cancel in-progress runs for the same branch/PR
 concurrency:
@@ -72,14 +77,15 @@ jobs:
     name: Detect Changes 🔍
     runs-on: ubuntu-latest
     outputs:
-      code: ${{ steps.filter.outputs.code }}
-      rust: ${{ steps.filter.outputs.rust }}
-      docker: ${{ steps.filter.outputs.docker }}
-      openapi: ${{ steps.filter.outputs.openapi }}
+      code: ${{ steps.resolve.outputs.code }}
+      rust: ${{ steps.resolve.outputs.rust }}
+      docker: ${{ steps.resolve.outputs.docker }}
+      openapi: ${{ steps.resolve.outputs.openapi }}
     steps:
       - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v3
         id: filter
+        if: github.event_name != 'workflow_dispatch'
         with:
           filters: |
             code:
@@ -98,6 +104,26 @@ jobs:
               - 'deploy/docker/**'
             openapi:
               - 'openapi/**'
+      - name: Resolve change outputs
+        id: resolve
+        if: always()
+        env:
+          EVENT: ${{ github.event_name }}
+          FORCE: ${{ github.event.inputs.force_build }}
+          CODE: ${{ steps.filter.outputs.code }}
+          RUST: ${{ steps.filter.outputs.rust }}
+          DOCKER: ${{ steps.filter.outputs.docker }}
+          OPENAPI: ${{ steps.filter.outputs.openapi }}
+        run: |
+          if [ "$EVENT" = "workflow_dispatch" ] && [ "$FORCE" = "true" ]; then
+            code="true"; rust="true"; docker="true"; openapi="true"
+          else
+            code="${CODE}"; rust="${RUST}"; docker="${DOCKER}"; openapi="${OPENAPI}"
+          fi
+          echo "code=${code}" >> "$GITHUB_OUTPUT"
+          echo "rust=${rust}" >> "$GITHUB_OUTPUT"
+          echo "docker=${docker}" >> "$GITHUB_OUTPUT"
+          echo "openapi=${openapi}" >> "$GITHUB_OUTPUT"
 
   test-workspace:
     name: Tests (Workspace) 🧪
@@ -213,6 +239,10 @@ jobs:
       - name: Detect delta vs latest release
         id: change
         run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ github.event.inputs.force_build }}" = "true" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           latest="${{ steps.latest.outputs.latest_tag }}"
           current="${{ steps.workspace_version.outputs.current_version }}"
           latest_stripped="${latest#v}"


### PR DESCRIPTION
## Summary

Adds support for manually triggering the pipeline (`workflow_dispatch`) to build and push the `user-storage` and `sms-gateway` images on demand, bypassing the normal change-detection and version-bump gates.

## Why

After a merge, the container images are only built when the workspace version is bumped (the `cargo-version` gate). There was no way to rebuild/push the images manually without making a code change with a version bump. This lets an operator force the build from the Actions UI.

## Changes (`.github/workflows/ci.yaml`)

1. **New `force_build` input** on `workflow_dispatch` (boolean, default `false`).
2. **`changes` job** — when `workflow_dispatch` + `force_build=true`, forces `code`/`rust`/`docker`/`openapi` to `true` so all downstream jobs run. On non-dispatch events (push/PR), behavior is unchanged (paths-filter results).
3. **`cargo-version` job** — when `workflow_dispatch` + `force_build=true`, reports `changed=true` so `container-build-prod` runs even without a version bump.

## How to use

- Go to **Actions → Main CI → Run workflow**.
- Set branch to a branch (e.g. `master`).
- Set **`force_build`** to `true` (optionally `skip_tests`/`skip_build`).
- The pipeline runs and pushes the images.

On `master`, `container-build-prod` pushes the `latest` tag used by the dev deployment; on other branches `container-build-dev` pushes `dev-<sha>` tags.

## Notes

- The `changes` job bypasses `dorny/paths-filter` on dispatch (since there is no diff to evaluate), so the filter step is skipped on `workflow_dispatch`.
- Version/change gates remain intact for regular push/PR runs, preserving the runner-cost optimization.